### PR TITLE
Add files via upload

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,0 +1,14 @@
+Arduino_LSM9DS1 ?.?.? - ????.??.??
+
+Arduino_LSM9DS1 1.0.0 - 2019.07.31
+
+* Initial release
+
+Arduino_LSM9DS1 1.1.0 - 2020.02.11
+
+* Added support for FIFO continuous reading of values
+
+Arduino_LSM9DS1 2.0.0 - 2020.05.15
+
+* Offset, Full scale, sample rate on all DOF.
+* Calibration parameters integrated

--- a/LSM9DS1_V2  notes and manual.txt
+++ b/LSM9DS1_V2  notes and manual.txt
@@ -1,0 +1,385 @@
+Notes on version 2.0 of the LSM9DS1 library
+Written by Femme Verbeek, Pijnacker, The Netherlands
+https://www.linkedin.com/in/femmeverbeek/
+23 may 2020
+
+
+Contents: 	
+			Introduction
+			Naming strategy
+			Output of Read method
+			Calibration
+				Offset
+				Slope
+				Offset and Slope Combined
+			Overview of Code
+			Derivation of linear correction
+				Offset
+				Slope
+
+*****************************************************************************************************************************
+*****************************************            Introduction              **********************************************
+*****************************************************************************************************************************
+
+The reason for writing this update is that the LSM9DS1 chip is not calibrated and the output may vary per instance of the chip.
+In my case the magnetic field offset was larger than the Earth magnetic field. The gyroscope offset of 3 deg/s does not sound 
+like much, but when trying to track the orientation it corresponds to a full circle misalignment in two minutes. Without 
+calibration it is impossible to make a working compass for sensing magnetic field or a gyro-compass, artificial horizon etc.
+
+This new version 2 provides a method to compensate for manufacturing differences between chips and produce calibrated output 
+on the read methods. This library does not provide prescribed useable methods for measuring or calibrating. The development
+of this is still the task of the user of this library. The examples are just for learning, but they are not part of the 
+library code itself. 
+
+New for all 9 DOF (degrees of freedom) is the possibility:
+   to set and get the sample rate frequency , 
+   to give it calibration zero offset and slope factors
+   to change the output unit
+   to change the internal full scale setting of the chip (IFS) giving it more accuracy at the expense of the range.
+
+With respect to version 1.1.0 almost all of the code was modified or added new. 
+With all new settings to their default values, programs using version 1.1.0 should still work and produce the same output.
+
+
+*****************************************************************************************************************************
+*****************************************            Naming strategy           **********************************************
+*****************************************************************************************************************************
+
+Keeping the same naming convention of version 1.1.0 resulted in very long names for the new functions, making formulas
+difficult to read, increasing the chance of making typo's and it was not always clear what was meant. 
+For this reason a number of shorter aliases were created most of them following the datasheet: 
+https://www.st.com/resource/en/datasheet/lsm9ds1.pdf
+
+Accel 	for Accelleration, 
+Gyro 	for Gyroscope, 
+Magnet 	for MagneticField, 
+ODR 	for SampleRate (= Output Data Rate), 
+FS 		for FullScale, 
+BW 		for BandWdth, 
+addition of "set" and "get" in the names of ODR, BW and FS functions. 
+
+e.g. magneticFieldSampleRate still works, but in the library code it is now getMagnetODR reflecting that it is not longer 
+a constant but a function that interrogates the LSM9DS1 chip. 
+
+Not used were the documentation's XL, M and G since it may confuse with gravity, Gauss and of course the size of clothes. :) 
+
+ 
+*****************************************************************************************************************************
+**********************************            Output of Read method              ****************************************
+*****************************************************************************************************************************
+
+Measuring the offset shows that it scales with the chip internal full scale setting (IFS). That means that it is caused 
+by the internal transducer and not by the DAC. So it is sufficient to calibrate for just one of the full scale settings 
+and compensate for the others by means of a multiplication.  
+
+The output of the read methods for each of the 9 DOF is now
+
+	Read 	=	Unit * Slope *(  (PFS / 32786 * Data - Offset )
+
+Data = the measurement value showing up on the chip registers	
+PFS = the in Program Full Scale setting (float LSM9DS1Class::get...FS() ) counteracting the internal chip setting so that 
+      the output result remains unchanged. 	
+Unit = the unit the measured physical property is expressed in. 
+Slope and Offset = calibration parameters.
+Note that the read method still produces the same output as in library version 1.01 on the condition that Slope = 1; 
+Offset=0; and Unit set to its default value.
+
+There are several ways in which a linear correction can be applied. The chosen method has the highest amount of advantages. 
+The offset and slope are independent of each other and of any of the other settings in the program. They can be measured 
+independently and really counteract the internal transducer differences. (For mathematical derivation see below)
+All Unit factors equal 1 for their default settings. 
+
+
+*****************************************************************************************************************************
+**********************************                   Calibration                     ****************************************
+*****************************************************************************************************************************
+
+In the text below ... stands for any of the three measurement properties, Accell, Gyro, Magnet. 
+
+For a full calibration we must find a set of two factors (Slope and Offset) for each property ...  and each of the three
+directions (x, y, z). So in total 18 calibration factors. 
+
+Following the procedures below, the calibration values are stored in the arrays ...Offset[3]={0,0,0} and ...Slope[3]={1,1,1} 
+Should you want to use these values again in a sketch, it's up to you to print them and put them in program code. 
+The library is designed in such a way that the stored values don't depend on any of the settings in the program, like ...Unit, 
+...SR  (sample rate), ...FS (full scale). So changing any of the settings before or after restoring their values in the
+arrays has no effect on the status of being calibrated. 
+
+*********************************************              Offset               *********************************************
+
+In order to find the value of Offset we must do a zero point measurement. That means that the physical property ... 
+we are trying to measure should actually result in a value of 0. E.g. keeping the board still should result in zero 
+gyroscope values for x,y and z. For acceleration the two axes perpendicular to the Earth gravity should be zero. 
+
+An offset calibration involves three steps
+1 set the offset factors to 0, using the set...Offset method
+2 do zero-point measurements with the read... method 
+3 store the measured ReadResults using the same set...Offset method to make the calibration effective.
+
+ad.1: in your sketch: IMO.set...Offset(0,0,0); 
+ad.2: The readResult should probably be the average value of a number of measurements
+ad.3: in your sketch: IMO.set...Offset(resultX,resultY,resultZ); 
+
+Alternatively if it is difficult to get a zero property, you could try to find the maximum and minimum values and 
+use the point in the middle
+
+		readResult = ( Read_max + Read_min ) / 2
+
+This is probably more complex than what it looks like. Both Read_min and Read_max can best be some sort of average, but 
+if you simply use the min() and max() procedures, the final results are just one measurement each. The chances are high 
+that these are the worst measurements. 
+Calculating separate averages of the min and max values, is like a chicken and egg. Before the calibration program can
+decide to which average a measurement belongs, it needs a rough calibration first.
+The best method is probably 3D elliptical regression, where the values of Offset correspond to the centre of the 
+elliptoid. So far I did not venture into the mathematics of this. :0 
+
+*********************************************              Slope               *********************************************
+  	
+Slope is a dimensionless number that compensates for the sensitivity of the chip's internal transducer. In case it is not
+possible to measure this, best leave it at the value 1. For Magnet and Accel this is probably allright, but for Gyro the 
+sensitivity matters if you want to keep track of orientation.
+
+A slope calibration involves three steps
+1 set the offset factor to 1, using the set...Slope method
+2 do slope measurements with the read... method 
+3 store the readResult using the same set...Slope method.
+
+ad.1: in your sketch: IMO.set...Slope(1,1,1); 
+ad.2: The read result should probably be two different averages of a number of measurements each
+ad.3: in your sketch: IMO.set...Slope(resultX,resultY,resultZ) 
+
+In order to calibrate the Slope parameter at least two measurements (say 1 and 2) must be done where the physical quantity, 
+(let's call it Q), has a known difference, so Q_1 - Q_2 = known value.
+
+The value of slope follows from 
+
+		Result = abs (( Q_1 - Q_2) / ( Read_1 - Read_2 ))      
+
+E.g. the Earth gravity should produce a value of 1g. Holding the board upside down should measure -1g. So the difference
+		( Q_1 - Q_2) = 2g
+The local strength of the magnetic field (in nT) can be found at
+https://en.wikipedia.org/wiki/Earth%27s_magnetic_field
+
+
+***************************************        Offset and Slope Combined           *********************************************
+
+With the above methods Slope and Offset can be measured independently. It does not matter which procedure comes first, 
+as long as you don't change any of the settings between measuring and assigning. This could accidently happen in case 
+of a combined measurement by setting the value of Slope before that of Offset.
+Note that the dimensionless stored Offset values differ from the Read measurements by a factor (Unit * Slope).
+
+
+A safe following order of steps is
+1 set the Slope factors to 1,          set...Slope(1,1,1); 
+2 set the Offset factors to 0,         set...Offset(0,0,0);
+3 do the measurements with the         read... method 
+4 First store the Offset results using set...Offset
+5 Store the Slope results second using set...Slope
+
+Example
+Lets assume that readAccel produces values of 1.3 and - 0.9 
+
+		Offset = (1.3 + (-0.9)) /  2  = 0.2    
+		Slope  =  (1 - (-1)) / (1.3 - (-0.9) = 2 / 2.2 = 0.90909
+
+Note that set...Offset stores the measured values as ReadResult/(Unit * Slope).
+If you store Slope first, the Offset becomes 0.2/0.90909 = 0.22
+
+*****************************************************************************************************************************
+**********************************                Overview of Code                   ****************************************
+*****************************************************************************************************************************
+
+(almost) unchanged 
+    int begin();
+    void end();
+    void setContinuousMode();
+    void setOneShotMode();
+    virtual int accelAvailable(); // Number of samples in the FIFO.
+    virtual int gyroAvailable(); // Number of samples in the FIFO.
+    virtual int magnetAvailable(); // Number of samples in the FIFO.
+
+existing functions changed for new functionality. Results reflect calibration, full scale and unit settings 
+    virtual int readAcceleration(float& x, float& y, float& z); // Results are in G (earth gravity) or m/s2.
+    virtual int readGyroscope(float& x, float& y, float& z); // Results are in degrees/second or rad/s.
+    virtual int readMagneticField(float& x, float& y, float& z); // Results are in uT (micro Tesla).
+
+existing functions that now actually do something
+    virtual float getAccelSR(); // Sampling rate of the sensor (Hz).
+    virtual float getGyroSR(); // Sampling rate of the sensor (Hz).
+    virtual float magnetSR(); // Sampling rate of the sensor (Hz).
+	
+New the possibility to change the ODR registers (Output Data Rate)	
+    virtual int setAccelSR(int8_t range); // 0:off, 1:10Hz, 2:50Hz, 3:119Hz, 4:238Hz, 5:476Hz, 6:952Hz, 7:NA
+    virtual int setGyroSR(int8_t range); // 0:off, 1:10Hz, 2:50Hz, 3:119Hz, 4:238Hz, 5:476Hz, 6:952Hz, 7:NA
+    virtual int setMagnetSR(int8_t range)  // range (0..7) corresponds to {0.625,1.25,2.5,5.0,10.0,20.0,40.0,80.0}Hz	
+
+New constants used in ..Unit setting
+#define GAUSS             1.0           
+#define MICROTESLA        100.0     // default
+#define GRAVITY           1.0       // default
+#define METERPERSECOND2   9.81  
+#define DEGREEPERSECOND   1.0       //default
+#define RADIANSPERSECOND  3.141592654/180
+
+Unit settings: 
+ 	float accelUnit = GRAVITY or METERPERSECOND2
+    float gyroUnit = DEGREEPERSECOND or RADIANSPERSECOND
+    float magnetUnit = MICROTESLA or GAUSS
+
+Calibration parameters Slope ans Offset : See Calibration.
+    float accelOffset[3] = {0,0,0}; // zero point offset correction factor for calibration
+	float gyroOffset[3] = {0,0,0};    // zero point offset correction factor for calibration
+	float magnetOffset[3] = {0,0,0};// zero point offset correction factor for calibration
+	float accelSlope[3] = {1,1,1};  // slope correction factor for calibration
+	float gyroSlope[3] = {1,1,1};     // slope correction factor for calibration
+	float magnetSlope[3] = {1,1,1}; // slope correction factor for calibration
+
+Methods for setting the calibration 
+	virtual void  setAccelOffset(float x, float y, float z);  
+	virtual void  setAccelSlope(float x, float y, float z);
+	virtual void  setGyroSlope(float x, float y, float z);
+    virtual int   setGyroSR(int8_t range); //Sampling Rate 0:off, 1:10Hz, 2:50Hz, 3:119Hz, 4:238Hz, 5:476Hz, 6:952Hz, 7:NA
+	virtual void  setMagnetOffset(float x, float y, float z);
+	virtual void  setMagnetSlope(float x, float y, float z);
+
+Unitsettings that read returns measurement results in.
+	float accelUnit = GRAVITY;          //  GRAVITY   OR  METERPERSECOND2 
+    float gyroUnit = DEGREEPERSECOND;   // DEGREEPERSECOND   or  RADIANSPERSECOND
+    float magnetUnit = MICROTESLA;      //  GAUSS   MICROTESLA  NANOTESLA
+
+New: changing the full scale sensitivity of the sensors.
+The functions modify the FS (full scale) registers of the LSM9DS1 chip changing sensitivity at the expence of range.
+Changing this setting does not change the x,y,z output of the read functions, but assigns just more or less bits
+to the sensor measurement. 
+    virtual int setAccelFS(int8_t range); // 0: ±2g ; 1: ±16g ; 2: ±4g ; 3: ±8g
+    virtual int setGyroFS(int8_t range); // 0= ±245 dps; 1= ±500 dps; 2= ±1000 dps; 3= ±2000 dps
+    virtual int setMagnetFS(int8_t range); // 0=400.0; 1=800.0; 2=1200.0 , 3=1600.0  (µT)
+*note* According to the data sheet gyroscope setting 2 = 1000 dps should not be available. For some reason it worked 
+  like a charm on my BLE Sense board, so I added the possibility.
+
+New functions return the Full Scale setting of the corresponding DOF as set with the corresponding set...FS functions
+    virtual float getAccelFS();  // output = 2.0,  16.0 , 4.0 , 8.0)  
+    virtual float getGyroFS();   // output = 245.0,  500.0 , 1000.0, 2000.0) 
+    virtual float getMagnetFS(); // output 400.0 ; 800.0 ; 1200.0 , 1600.0      
+
+
+*****************************************************************************************************************************
+**********************************       Derivation of  linear correction            ****************************************
+*****************************************************************************************************************************
+
+*******************************************             Offset            ***************************************************
+
+
+Sorry for the very formal derivation below. It suits verifiability but probably only my own purpose :)
+It took a lot of puzzling to get it right. Don't read it if you don't want to. :(
+
+Assuming good linearity of the transducer, we can model the data output of the chip as
+
+            Data = (32768 / IFS) *( A*Q + B)												(1)
+
+Data = the measured value showing up on the chip registers
+Q = the actual physical quantity we are trying to measure in any of the 9 DOF
+IFS = the chip Internal Fullscale Setting.  
+A,B unknown constants representing chip instance differences
+
+Since the chip outputs dimensionless bits and bytes only, the dimensions of IFS and B must equal the dimension of Q.  
+
+The challenge is to get rid of the unknown constants A and B and translate them into measurable quantities produced by the 
+library's Read methods. Since a good calibrated Read should produce a number equal to the actual physical quantity 
+we can state  
+
+			Read = Q	
+			
+Further, we do not want to recalibrate when we change the Full Scale setting or the Unit.
+
+Define
+PFS = the in-program Full Scale function counteracting the IFS so that the output result remains unchanged. 
+      (dimensionless, but its value corresponds to that of the chosen default unit) 
+Slope = in-program correction factor for the sensor sensitivity
+Offset = in-program correction factor for the sensor zero point offset
+
+The output of the read methods is (see above)
+
+		Read 	=	Unit * Slope * (PFS / 32786 * Data - Offset )							(2)
+			 
+Substitute eq(1)
+
+		Read	=	Unit * slope * (PFS / IFS * 32786/32786 * ( A*Q + B ) - Offset )
+	
+		Read	=	Unit * slope * (PFS / IFS * ( A*Q + B ) - Offset )						(3)
+	
+In case of the calibrated zero point measurement   Q = Read = 0   
+Substitute  in eq.(3) we get
+
+		0	=	Unit * slope * (PFS / IFS * ( A*0 + B ) - Offset )	
+
+		Unit * slope *	Offset  =	Unit * slope * PFS / IFS * B 							(4)
+		
+For an uncalibrated measurement of a zero point (ZP) filling in  Offset=0 and Q=0 in eq(3) we get 
+	
+		Read_uncalibrated_ZP  =  Unit * slope * PFS / IFS * B								(5)
+
+The righthand terms in equation (4) and (5) are identical so it follows that 
+
+		Offset  =  read_uncalibrated_ZP / (Unit * slope)									(6)
+
+This defines how we should do the calibration measurements. In the library the methods called set...Offset 
+use of eq(6) to assign the uncalibrated zero-point read values to the corresponding program parameters.
+Eq.(6) suggests that Offset depends on Unit and Slope, but this is not the case as the Read method scales 
+with the same value. To proof this we write eg(4) in a different form
+
+		Offset	=  (Unit * Slope) / (Unit * Slope) * PFS/IFS *  B   						(7)
+  
+Further	since the dimensionless PFS counteracts IFS in size 
+and the dimension of IFS equals that of Q, the ratio PFS/IFS is 1/Unit.
+or in other words  
+
+		Unit * PFS /IFS = 1																	(8)
+			
+eq(7) reduces to  
+
+		Offset  = B	/ Unit	= B																(9)
+
+So Offset equals the dimensionless form of B and does not depend on any other parameter.
+
+
+********************************************             Slope            ***************************************************
+
+In order to calibrate the Slope at least two measurements (say 1 and 2) must be done where the measured quantity Q 
+has a known difference. The calibrated Read equals Q so
+
+		Q_1 - Q_2 	= Read_1 - Read_2 = known value											(10)
+
+Substitute eq(2)
+
+		Q_1 - Q_2	= Unit*Slope*(PFS/32786*Data_1 - Offset) - Unit*Slope*(PFS/32786*Data_2 - Offset)
+
+					= Unit*Slope*(PFS/32786*(Data_1 - Data_2)								(11)
+						
+So the difference between the measurements gets rid of the Offset
+For an uncalibrated measurement we must set   Slope = 1. 
+Eq(2) becomes 
+
+		Read_uncalibrated  =  Unit * (PFS / 32786 * Data - Offset )
+
+In eq(11) we get
+
+		Q_1 -Q_2  = Slope * ( Read_uncalibrated_1 - Read_uncalibrated_2)
+
+		Slope 	=	(( Read_uncalibrated_1 - Read_uncalibrated_2) / (Q_1 -Q_2)				(12)
+
+So in order to measure the slope we must first set the Slope parameter to 1. 
+
+In order to prove that Slope is independent of all the other program parameters we substitute eq(1) in eq(11)
+
+		Q_1 - Q_2	= Unit*Slope*(PFS/32786)*(32786/IFS)*(A*Q1 +B - A*Q2 -B))
+						
+	   (Q_1 - Q_2)	= Slope*  Unit*(PFS/IFS)* A *(Q1 - Q2)									(12)
+
+and with eq(8) 			
+
+		(	1	)	= Slope *      1        * A *(   1   )
+			
+			Slope 	= 1 / A
+ 
+QED

--- a/examples/LSM9DS1_RegisterTest/LSM9DS1_RegisterTest.ino
+++ b/examples/LSM9DS1_RegisterTest/LSM9DS1_RegisterTest.ino
@@ -1,0 +1,68 @@
+/*Test program for Arduino__LSM9DS1 Library version 2.0 extensions
+ * Written by Femme Verbeek Pijnacker the Netherlands 23 may 2020.
+ * Run through all the new set and get functions
+ */
+
+#include <Arduino_LSM9DS1.h>
+
+void setup() {
+   Serial.begin(115200);
+   while(!Serial);
+   Serial.println();
+     if (!IMU.begin()) {
+    Serial.println("Failed to initialize IMU!");
+    while (1); }
+
+   for (int i = 0;i<=3;i++){
+      if (IMU.setAccelFS(i))
+         printResult ("Accelleration Full Scale range param = ", i ,IMU.getAccelFS()," g ");
+      else Serial.println ("failed setting accelleration scale value "); } 
+
+   for (int i = 0;i<=3;i++){
+      if (IMU.setGyroFS(i))  
+        printResult ("Gyroscope Full Scale range param = ",i,IMU.getGyroFS()," deg/s ");
+      else Serial.println ("failed setting gyroscope scale value ");}
+ 
+   for (int i = 0;i<=3;i++){
+      if (IMU.setMagnetFS(i))
+         printResult ("magnetic range param = ", i ,IMU.getMagnetFS()," µT ");
+      else Serial.println ("failed setting magnetic field scale value "); } 
+      
+   for (int i = 0;i<=7;i++){
+      if (IMU.setAccelODR(i))
+      {  printResult ("accelleration sample rate param = ", i , IMU.getAccelODR()," Hz ");
+       //  printResult ("Gyroscope sample rate param = ", i , IMU.getGyroODR()," Hz ");
+         Serial.println(" automatic bandwidth setting (Hz) "+ String (IMU.getAccelBW()));
+         for (int j = 0;j<=3;j++)
+         {   IMU.setAccelBW(j);    // override automatic bandwith
+             printResult("Accel bandwidth override ", j ,IMU.getAccelBW(), "Hz " );
+         }
+      } 
+      else Serial.println ("failed setting accelleration sample rate ");}
+ 
+   for (int i = 0;i<=7;i++){
+      if (IMU.setGyroODR(i)){
+        printResult ("gyroscope sample rate param = ", i , IMU.getGyroODR(),"  Hz" );
+         for (int j = 0;j<=3;j++)
+         {   IMU.setGyroBW(j);    // override automatic bandwith
+             printResult("Gyro bandwidth setting ", j ,IMU.getGyroBW(), "Hz " );
+         }    
+      }
+      else Serial.println ("failed setting gyroscope sample rate "); }
+ 
+   for (int i = 0;i<=7;i++){
+      if (IMU.setMagnetODR(i))
+        printResult ("magnetic field sample rate param = ", i , IMU.getMagnetODR()," Hz ");
+      else Serial.println ("failed setting magnetic field sample rate ");}      
+}
+
+void loop() {
+
+}
+
+void printResult (String msg, int nr,float value, String dimension)
+      { Serial.print (msg+String(nr));
+      //  Serial.print (nr); 
+        Serial.print(" setting "+String(value));
+    //    Serial.print(value);
+        Serial.println(dimension);}

--- a/examples/LSM9DS1_calibrate_gyro_offset/LSM9DS1_calibrate_gyro_offset.ino
+++ b/examples/LSM9DS1_calibrate_gyro_offset/LSM9DS1_calibrate_gyro_offset.ino
@@ -1,0 +1,76 @@
+/*Example program for Arduino__LSM9DS1 Library version 2.0 
+ * Tested on Arduino Nano 33 BLE SENSE 
+ * Written by Femme Verbeek 15 may 2020.
+ * 
+ * Measures the gyroscope offset and sets the IMU.gyroOffset parameters for X,Y,Z
+ * To start the calibration measurement, open the serial monitor.
+ * For a good result the board must be held still during the calibration measurements
+ * During the calibration the onboard LED's are blinking
+ * When finished the program prints the calibration result 
+ * The program pauses till you press enter
+ * Next the program will continue measuring and print the now calibrated results. 
+ * Best close the serial monitor first, open the serial monitor and send the character from there.  
+ * 
+ * To see a graphic result of the measurements, close the serial monitor when the program pauses,
+ * open the serial plotter, type any character and press "send".
+ */
+const int averageNSamples=10;  //average output over N measurements
+
+#include <Arduino_LSM9DS1.h>
+//unsigned long timer;
+void setup() 
+{  Serial.begin(115200);
+   while(!Serial);
+   delay(1);
+   if (!IMU.begin()) {
+      Serial.println("Failed to initialize IMU!");
+      while (1); }
+   IMU.setGyroODR(4); //Sampling Rate 0:off, 1:10Hz, 2:50Hz, 3:119Hz, 4:238Hz, 5:476Hz, 6:952Hz, 7:NA
+   IMU.setGyroBW(0); // bandwidth see table 47 datasheet
+   Serial.print("Gyro ODR "+String( IMU.getGyroODR()  ) );
+   Serial.println(" BW setting "+String( IMU.getGyroBW()  ) );
+   Serial.println("Calibrating. Just a moment. ");
+   Serial.println("Keep the sensor still as long as the LED's are flashing");
+
+   calibrateGyroOffset(12000); // do calibration measurements during 12000 ms. 
+ 
+   Serial.println("calibration results"); 
+   Serial.print("Content of IMU.gyroOffset : "); 
+   for (int i= 0; i<=2 ; i++) {Serial.print(IMU.gyroOffset[i],6);Serial.print("  ");}
+   Serial.println();
+   Serial.println("Press enter to start mesuring");
+   Serial.println("To see a graph of the measurements, close this serial monitor, open the serial plotter type any character and click the send button");
+   while (!Serial.available());    // pause the program, enter continues
+   while (Serial.available()) Serial.read();   // clear the read buffer
+   Serial.println(" X \t Y \t Z ");
+}
+
+// continue doing calibrated measurements, this is best viewed in the serial plotter
+void loop()       
+{  float x, y, z, averX=0, averY=0, averZ=0;
+   for (int i=1;i<=averageNSamples;i++)
+   {  while (!IMU.gyroAvailable());
+       IMU.readGyro(x, y, z);
+       averX += x; averY += y; averZ += z;
+   }
+   Serial.print(String(averX/averageNSamples,6)+'\t');
+   Serial.print(String(averY/averageNSamples,6)+'\t');
+   Serial.println(averZ/averageNSamples,6);          
+}
+    
+void calibrateGyroOffset(unsigned int duration){  // don't move the board during calibration
+unsigned long count = 0, start = millis();
+float x, y, z, addX=0, addY=0, addZ=0  ;
+       IMU.setGyroOffset(0,0,0);  // Offsets must be zero when calibrating
+       while ((millis()-start) < duration)
+       { if (IMU.gyroscopeAvailable())
+         {  IMU.readGyroscope(x, y, z);  
+            count++;
+            addX += x; addY += y; addZ += z;
+            digitalWrite(LED_BUILTIN, (millis()/125)%2);       // blink onboard led every 250ms
+         }
+       } 
+       IMU.setGyroOffset(addX/count, addY/count, addZ/count); // Store the average measurements as offset
+       digitalWrite(LED_BUILTIN, 0);       // onboard led off
+       Serial.println("nr of samples "+String(count));
+}   

--- a/examples/LSM9DS1_calibrated_XY_compass/LSM9DS1_calibrated_XY_compass.ino
+++ b/examples/LSM9DS1_calibrated_XY_compass/LSM9DS1_calibrated_XY_compass.ino
@@ -1,0 +1,93 @@
+/* Calibrated compass example for the Nano 33 BLE Sense
+ * You need version 2.0 or higher of the LMS9DS1 library to run this example 
+ * 
+ * The compass must be calibrated for the magnetic disturbance of the environment.
+ * Calibration starts automaticlly when the serial monitor is opened and stops after a given time. 
+ * Calibration in progress is indicated by the flashing onboard LED.
+ * 
+ * During calibration the board must be turned slowly over a full 360 deg. 
+ * When finished calibrating the program stores and prints the offset and slope factors. 
+ * 
+ * After pressing "enter" the program continues working as a compass. 
+ * 
+ * Written by Femme Verbeek 2020  
+ * Released to the public domain
+*/
+
+#include <Arduino_LSM9DS1.h>
+
+float EarthMagField = 49000;  //= nT    For local value see https://en.wikipedia.org/wiki/Earth%27s_magnetic_field
+int averageCompassByN = 10;       //number of samples per compass reading. Higher number = more accurate but slower
+int averageCalibrationByN = 10;   //goldielocs number too high = fewer measurements in 360deg turn, to low = more noise
+int calibrationTime = 20; //s
+void setup() {
+     pinMode(LED_BUILTIN,OUTPUT);
+     Serial.begin(115200);
+     while(!Serial);                     // wait till the serial monitor connects
+     delay(1);
+     if (!IMU.begin()) {  
+        Serial.println("Failed to initialize IMU!");  
+        while (1); }
+     IMU.setMagnetODR(7);         // Sample Rate (0..7) corresponds to {0.625,1.25,2.5,5.0,10.0,20.0,40.0,80.0}Hz
+     IMU.magnetUnit =  NANOTESLA;     // calibrate in nanotesla as this corresponds to the local field strenth number we found.
+     Serial.println("Calibrating. Just a moment. ");
+     Serial.println("Keep the compass sensor horizontal.");
+     Serial.print("In the next "+String(calibrationTime));
+     Serial.println(" seconds the compass must be turned slowly over a full 360 degrees!");
+
+     calibrateMagnet(calibrationTime*1000);
+
+     Serial.println("calibration results"); 
+     Serial.print("IMU.magnetOffset[] : "); 
+     for (int i= 0; i<=2 ; i++){ Serial.print(IMU.magnetOffset[i],4);Serial.print("  ");}
+     Serial.println();
+     Serial.print("IMU.magnetSlope[]  : "); 
+     for (int i= 0; i<=2 ; i++){ Serial.print(IMU.magnetSlope[i],4);Serial.print("  ");}
+     Serial.println();
+     Serial.println("Press enter to start the compass");
+     while (!Serial.available());    // pause the program, enter continues, use the serial plotter to view a graph
+     while (Serial.available()) Serial.read();   // clear the read buffer
+     Serial.println("Direction\tFieldStrength\tmagX\tmagY");          // legend for serial plotter
+     IMU.magnetUnit = MICROTESLA;        // Switch to microtesla as this looks better in the graph
+
+}
+
+void loop ()
+{  float magY,magX;
+   doNMeasurements (averageCompassByN,magX,magY,false);
+   float heading= atan2(magY,magX)*180/PI +180;
+   float fieldStrength = sqrt(magX*magX +magY * magY);
+   Serial.print(heading); Serial.print("\t");   Serial.print(fieldStrength);Serial.print("\t");
+   Serial.print(magX); Serial.print("\t");   Serial.print(magY);Serial.print("\t");
+   Serial.println();
+}
+
+void doNMeasurements(unsigned int N, float& averX, float& averY, boolean showLeds) 
+{    float x, y, z;
+     averX=0; averY =0;
+     for (int i=1;i<=N;i++)
+     {  digitalWrite(LED_BUILTIN, bitRead(millis(),7)&& showLeds );       // blink onboard led
+        while (!IMU.magneticFieldAvailable());
+        IMU.readMagneticField(x, y, z);
+        averX += x/N;
+        averY += y/N;
+     } 
+}
+ 
+void calibrateMagnet(unsigned int duration)  // measure Offset and Slope of XY
+{  float x, y, Xmin, Xmax, Ymin, Ymax  ;
+   IMU.setMagnetOffset(0,0,0);                      // Offsets must be 0 when calibrating
+   IMU.setMagnetSlope(1,1,1);                       // slopes must be 1 when calibrating
+   doNMeasurements(averageCalibrationByN,Xmin, Ymin, true ); // find some starting values
+   Xmax = Xmin; Ymax = Ymin;
+   unsigned long  start = millis(); 
+   while ((millis()-start) < duration)
+   {    doNMeasurements(averageCompassByN ,x, y ,true);
+        Xmax = max (Xmax, x); Xmin = min (Xmin, x);
+        Ymax = max (Ymax, y); Ymin = min (Ymin, y);
+   } 
+   IMU.setMagnetOffset( (Xmax+Xmin)/2,(Ymax+Ymin)/2, 0 ) ;                                      // store offset
+   IMU.setMagnetSlope ( (2*EarthMagField)/(Xmax-Xmin),(2*EarthMagField)/(Ymax-Ymin),1) ;        // store slope  
+//   Serial.print("Xmin = ");Serial.print(Xmin); Serial.print("  Xmax = ");Serial.println(Xmax);
+//   Serial.print("Ymin = ");Serial.print(Ymin); Serial.print("  Ymax = ");Serial.println(Ymax);
+}   

--- a/keywords.txt
+++ b/keywords.txt
@@ -14,19 +14,85 @@ IMU	KEYWORD1
 
 begin	KEYWORD2
 end	KEYWORD2
+setContinuousMode	KEYWORD2
+setOneShotMode	KEYWORD2
 
 readAcceleration	KEYWORD2
 readGyroscope	KEYWORD2
 readMagneticField	KEYWORD2
-gyroscopeAvailable	KEYWORD2
+
+readAccel	KEYWORD2
+readGyro	KEYWORD2
+readMagnet	KEYWORD2
+
 accelerationAvailable	KEYWORD2
+gyroscopeAvailable	KEYWORD2
 magneticFieldAvailable	KEYWORD2
+
+accelAvailable	KEYWORD2
+gyroAvailable	KEYWORD2
+magnetAvailable	KEYWORD2
+
 accelerationSampleRate	KEYWORD2
 gyroscopeSampleRate	KEYWORD2
 magneticFieldSampleRate	KEYWORD2
-setContinuousMode	KEYWORD2
-setOneShotMode	KEYWORD2
+
+setAccelerationSampleRate	KEYWORD2
+setGyroscopeSampleRate	KEYWORD2
+setMagneticFieldSampleRate	KEYWORD2
+
+accelOffset	KEYWORD2
+gyroOffset	KEYWORD2
+magnetOffset	KEYWORD2
+
+accelScale	KEYWORD2
+gyroScale	KEYWORD2
+magnetScale	KEYWORD2
+
+accelUnit	KEYWORD2
+gyroUnit	KEYWORD2
+magnetUnit	KEYWORD2
+
+accelerationFullScale	KEYWORD2
+gyroscopeFullScale	KEYWORD2
+magneticFieldFullScale	KEYWORD2
+
+setAccelerationFullScale	KEYWORD2
+setGyroscopeFullScale	KEYWORD2
+setMagneticFieldFullScale	KEYWORD2
+
+getAccelODR	KEYWORD2
+getGyroODR	KEYWORD2
+getMagnetODR	KEYWORD2
+setAccelODR	KEYWORD2
+setGyroODR	KEYWORD2
+setMagnetODR	KEYWORD2
+
+getAccelFS	KEYWORD2
+getGyroFS	KEYWORD2
+getMagnetFS	KEYWORD2
+setAccelFS	KEYWORD2
+setGyroFS	KEYWORD2
+setMagnetFS	KEYWORD2
+
+setAccelBW	KEYWORD2
+getAccelBW	KEYWORD2
+setGyroBW	KEYWORD2
+getGyroBW	KEYWORD2
+
+readAccel	KEYWORD2
+readGyro	KEYWORD2
+readMagnet	KEYWORD2
+
+
 
 #######################################
 # Constants
 #######################################
+
+GAUSS	LITERAL1
+MICROTESLA	LITERAL1
+GRAVITY	LITERAL1
+METERPERSECOND2	LITERAL1
+DEGREEPERSECOND	LITERAL1
+RADIANSPERSECOND	LITERAL1

--- a/src/LSM9DS1.cpp
+++ b/src/LSM9DS1.cpp
@@ -15,6 +15,11 @@
   You should have received a copy of the GNU Lesser General Public
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+  
+  Modifications by Femme Verbeek, Pijnacker, the Netherlands 23 may 2020, 
+  Released to the public domain
+  version 2.0.0
+  
 */
 
 #include "LSM9DS1.h"
@@ -37,6 +42,14 @@
 #define LSM9DS1_CTRL_REG3_M        0x22
 #define LSM9DS1_STATUS_REG_M       0x27
 #define LSM9DS1_OUT_X_L_M          0x28
+
+// Add these right after defines at the beginning
+#define LSM9DS1_OFFSET_X_REG_L_M   0x05
+#define LSM9DS1_OFFSET_X_REG_H_M   0x06
+#define LSM9DS1_OFFSET_Y_REG_L_M   0x07
+#define LSM9DS1_OFFSET_Y_REG_H_M   0x08
+#define LSM9DS1_OFFSET_Z_REG_L_M   0x09
+#define LSM9DS1_OFFSET_Z_REG_H_M   0x0A
 
 LSM9DS1Class::LSM9DS1Class(TwoWire& wire) :
   continuousMode(false), _wire(&wire)
@@ -106,26 +119,25 @@ void LSM9DS1Class::end()
   _wire->end();
 }
 
-int LSM9DS1Class::readAcceleration(float& x, float& y, float& z)
-{
-  int16_t data[3];
+//************************************      Accelleration      *****************************************
 
+int LSM9DS1Class::readAccel(float& x, float& y, float& z)
+{ int16_t data[3];
   if (!readRegisters(LSM9DS1_ADDRESS, LSM9DS1_OUT_X_XL, (uint8_t*)data, sizeof(data))) {
     x = NAN;
     y = NAN;
     z = NAN;
-
     return 0;
   }
-
-  x = data[0] * 4.0 / 32768.0;
-  y = data[1] * 4.0 / 32768.0;
-  z = data[2] * 4.0 / 32768.0;
-
+  // See releasenotes   	read =	Unit * Slope * (PFS / 32786 * Data - Offset )
+  float scale =  getAccelFS()/32768.0 ;   
+  x = accelUnit * accelSlope[0] * (scale * data[0] - accelOffset[0]);
+  y = accelUnit * accelSlope[1] * (scale * data[1] - accelOffset[1]);
+  z = accelUnit * accelSlope[2] * (scale * data[2] - accelOffset[2]);
   return 1;
 }
 
-int LSM9DS1Class::accelerationAvailable()
+int LSM9DS1Class::accelAvailable()
 {
   if (continuousMode) {
     // Read FIFO_SRC. If any of the rightmost 8 bits have a value, there is data.
@@ -137,80 +149,210 @@ int LSM9DS1Class::accelerationAvailable()
       return 1;
     }
   }
-
   return 0;
 }
 
-float LSM9DS1Class::accelerationSampleRate()
-{
-  return 119.0F;
+void LSM9DS1Class::setAccelOffset(float x, float y, float z) //Look out, from measurements only
+{  accelOffset[0] = x /(accelUnit * accelSlope[0]);
+   accelOffset[1] = y /(accelUnit * accelSlope[1]);
+   accelOffset[2] = z /(accelUnit * accelSlope[2]);
 }
 
-int LSM9DS1Class::readGyroscope(float& x, float& y, float& z)
-{
-  int16_t data[3];
+void LSM9DS1Class::setAccelSlope(float x, float y, float z) 
+{  accelSlope[0] = x ;
+   accelSlope[1] = y ;
+   accelSlope[2] = z ;
+}
 
-  if (!readRegisters(LSM9DS1_ADDRESS, LSM9DS1_OUT_X_G, (uint8_t*)data, sizeof(data))) {
-    x = NAN;
+int LSM9DS1Class::setAccelODR(int8_t range) //Sample Rate 0:off, 1:10Hz, 2:50Hz, 3:119Hz, 4:238Hz, 5:476Hz, 6:952Hz, 7:NA
+{  if (range==7) range =0; 
+   range = (range & B00000111) << 5;
+   uint8_t setting = ((readRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG6_XL) & B00011111) | range);
+   return writeRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG6_XL,setting) ;
+}
+float LSM9DS1Class::getAccelODR()
+{  float Ranges[] ={0.0, 10.0, 50.0, 119.0, 238.0, 476.0, 952.0, 0.0 };
+   uint8_t setting = readRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG6_XL)  >> 5;
+   return Ranges [setting];
+}
+
+float LSM9DS1Class::setAccelBW(int8_t range) //0,1,2,3 Override autoBandwidth setting see doc.table 67
+{ range = range & B00000011;
+  uint8_t RegIs = readRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG6_XL) & B11111000;
+  RegIs = RegIs | B00000100 | range ;
+  return writeRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG6_XL,RegIs) ;
+}
+
+float LSM9DS1Class::getAccelBW() //Bandwidth setting 0,1,2,3  see documentation table 67
+{ float autoRange[] ={0.0, 408.0, 408.0, 50.0, 105.0, 211.0, 408.0, 0.0 };
+  float BWXLRange[] ={ 408.0, 211.0, 105.0, 50.0 };
+  uint8_t RegIs = readRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG6_XL);
+  if (bitRead(2,RegIs))  return BWXLRange [RegIs & B00000011];    
+  else return autoRange [ RegIs >> 5 ];
+}
+
+int LSM9DS1Class::setAccelFS(int8_t range) // 0: ±2g ; 1: ±16g ; 2: ±4g ; 3: ±8g  
+{	range = (range & B00000011) << 3;
+	uint8_t setting = ((readRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG6_XL) & 0xE7) | range);
+	return writeRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG6_XL,setting) ;
+}
+
+float LSM9DS1Class::getAccelFS() // Full scale (output = 2.0,  16.0 , 4.0 , 8.0)  
+{ float ranges[] ={2.0, 16.0, 4.0, 8.0}; //g
+  uint8_t setting = (readRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG6_XL) & 0x18) >> 3;
+  return ranges[setting] ;
+}
+
+//************************************      Gyroscope      *****************************************
+
+int LSM9DS1Class::readGyro(float& x, float& y, float& z)
+{ int16_t data[3];
+  if (!readRegisters(LSM9DS1_ADDRESS, LSM9DS1_OUT_X_G, (uint8_t*)data, sizeof(data))) 
+  { x = NAN;
     y = NAN;
     z = NAN;
-
     return 0;
   }
-
-  x = data[0] * 2000.0 / 32768.0;
-  y = data[1] * 2000.0 / 32768.0;
-  z = data[2] * 2000.0 / 32768.0;
-
+  float scale = getGyroFS() / 32768.0;
+  x = gyroUnit * gyroSlope[0] * (scale * data[0] - gyroOffset[0]);
+  y = gyroUnit * gyroSlope[1] * (scale * data[1] - gyroOffset[1]);
+  z = gyroUnit * gyroSlope[2] * (scale * data[2] - gyroOffset[2]);
   return 1;
 }
 
-int LSM9DS1Class::gyroscopeAvailable()
+int LSM9DS1Class::gyroAvailable()
 {
   if (readRegister(LSM9DS1_ADDRESS, LSM9DS1_STATUS_REG) & 0x02) {
     return 1;
   }
-
   return 0;
 }
 
-float LSM9DS1Class::gyroscopeSampleRate()
-{
-  return 119.0F;
+void LSM9DS1Class::setGyroOffset(float x, float y, float z) //Look out, from measurements only
+{  gyroOffset[0] = x /(gyroUnit * gyroSlope[0]);
+   gyroOffset[1] = y /(gyroUnit * gyroSlope[1]);
+   gyroOffset[2] = z /(gyroUnit * gyroSlope[2]);
 }
 
+void LSM9DS1Class::setGyroSlope(float x, float y, float z) 
+{  gyroSlope[0] = x ;
+   gyroSlope[1] = y ;
+   gyroSlope[2] = z ;
+}
+  
+int LSM9DS1Class::setGyroODR(int8_t range) // 0:off, 1:10Hz, 2:50Hz, 3:119Hz, 4:238Hz, 5:476Hz, 6:952Hz, 7:NA
+{  if (range==7) range =0; 
+   range = (range & B00000111) << 5;
+   uint8_t setting = ((readRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG1_G) & B00011111) | range);
+   return writeRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG1_G,setting) ;	
+}
+
+float LSM9DS1Class::getGyroODR()
+{  float Ranges[] ={0.0, 10.0, 50.0, 119.0, 238.0, 476.0, 952.0, 0.0 };  //Hz
+   uint8_t setting = readRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG1_G)  >> 5;
+   return Ranges [setting]; //   return 119.0F;
+}
+
+int LSM9DS1Class::setGyroBW(int8_t range)
+{  range = range & B00000011;
+   uint8_t setting = readRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG1_G) & B11111100;
+   return writeRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG1_G,setting | range) ;	
+}
+
+#define ODRrows 8
+#define BWcols 4
+float BWtable[ ODRrows ][ BWcols ] =      // acc to 
+       {  { 0,  0,  0,  0   }, 
+          { 0,  0,  0,  0   },
+          { 16, 16, 16, 16  },
+          { 14, 31, 31, 31  },
+          { 14, 29, 63, 78  },
+          { 21, 28, 57, 100 },
+          { 33, 40, 58, 100 },
+          { 0,  0,  0,  0   }   };
+
+float LSM9DS1Class::getGyroBW()
+{  uint8_t setting = readRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG1_G) ;
+   uint8_t ODR = setting >> 5;
+   uint8_t BW = setting & B00000011;
+   return BWtable[ODR][BW];
+}
+   
+int LSM9DS1Class::setGyroFS(int8_t range) // (0: 245 dps; 1: 500 dps; 2: 1000  dps; 3: 2000 dps)
+{    range = (range & B00000011) << 3;	
+	 uint8_t setting = ((readRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG1_G) & 0xE7) | range );
+	 return writeRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG1_G,setting) ;
+}
+
+float LSM9DS1Class::getGyroFS() //   
+{ float Ranges[] ={245.0, 500.0, 1000.0, 2000.0}; //dps
+  uint8_t setting = (readRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG1_G) & 0x18) >> 3;
+  return Ranges[setting] ;
+}
+
+//************************************      Magnetic field      *****************************************
+
 int LSM9DS1Class::readMagneticField(float& x, float& y, float& z)
-{
-  int16_t data[3];
+{  int16_t data[3];
 
   if (!readRegisters(LSM9DS1_ADDRESS_M, LSM9DS1_OUT_X_L_M, (uint8_t*)data, sizeof(data))) {
     x = NAN;
     y = NAN;
     z = NAN;
-
     return 0;
   }
-
-  x = data[0] * 4.0 * 100.0 / 32768.0;
-  y = data[1] * 4.0 * 100.0 / 32768.0;
-  z = data[2] * 4.0 * 100.0 / 32768.0;
-
+  float scale = getMagnetFS() / 32768.0;
+  x = magnetUnit * magnetSlope[0] * (scale * data[0] - magnetOffset[0]);
+  y = magnetUnit * magnetSlope[1] * (scale * data[1] - magnetOffset[1]);
+  z = magnetUnit * magnetSlope[2] * (scale * data[2] - magnetOffset[2]);
   return 1;
 }
 
 int LSM9DS1Class::magneticFieldAvailable()
-{
+{ //return (readRegister(LSM9DS1_ADDRESS_M, LSM9DS1_STATUS_REG_M) & 0x08)==0x08;
   if (readRegister(LSM9DS1_ADDRESS_M, LSM9DS1_STATUS_REG_M) & 0x08) {
     return 1;
   }
-
   return 0;
 }
 
-float LSM9DS1Class::magneticFieldSampleRate()
-{
-  return 20.0;
+void LSM9DS1Class::setMagnetOffset(float x, float y, float z) //Look out, from measurements only
+{  magnetOffset[0] = x /(magnetUnit * magnetSlope[0]);
+   magnetOffset[1] = y /(magnetUnit * magnetSlope[1]);
+   magnetOffset[2] = z /(magnetUnit * magnetSlope[2]);
 }
+
+void LSM9DS1Class::setMagnetSlope(float x, float y, float z) 
+{  magnetSlope[0] = x ;
+   magnetSlope[1] = y ;
+   magnetSlope[2] = z ;
+}
+	
+int LSM9DS1Class::setMagnetFS(int8_t range) // 0=400.0; 1=800.0; 2=1200.0 , 3=1600.0  (µT)
+{    range = (range & B00000011) << 5;	
+	 return writeRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG2_M,range) ;
+}
+
+float LSM9DS1Class::getMagnetFS() //   
+{ const float Ranges[] ={400.0, 800.0, 1200.0, 1600.0}; //
+  uint8_t setting = readRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG2_M)  >> 5;
+  return  Ranges[setting] ;
+}
+
+int LSM9DS1Class::setMagnetODR(int8_t range)  // range (0..7) corresponds to {0.625,1.25,2.5,5.0,10.0,20.0,40.0,80.0}Hz
+{ range = (range & B00000111) << 2;
+   uint8_t setting = ((readRegister(LSM9DS1_ADDRESS_M, LSM9DS1_CTRL_REG1_M) & B11100011) | range);
+   return writeRegister(LSM9DS1_ADDRESS_M, LSM9DS1_CTRL_REG1_M,setting) ;	 
+}
+
+float LSM9DS1Class::getMagnetODR()  // Output {0.625, 1.25, 2.5, 5.0, 10.0, 20.0, 40.0 , 80.0}; //Hz
+{ const float ranges[] ={0.625, 1.25,2.5, 5.0, 10.0, 20.0, 40.0 , 80.0}; //Hz
+  uint8_t setting = (readRegister(LSM9DS1_ADDRESS_M, LSM9DS1_CTRL_REG1_M) & B00011100) >> 2;
+  return ranges[setting];
+}
+
+//************************************      Private functions      *****************************************
+
 
 int LSM9DS1Class::readRegister(uint8_t slaveAddress, uint8_t address)
 {

--- a/src/LSM9DS1.h
+++ b/src/LSM9DS1.h
@@ -15,10 +15,49 @@
   You should have received a copy of the GNU Lesser General Public
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+  
+  Modifications by Femme Verbeek, Pijnacker, the Netherlands 23 may 2020, 
+  Released to the public domain
+  version 2.0.0
 */
+
+#ifndef LSM9DS1_V2.0
+      #define LSM9DS1_V2.0
+#endif	  
+
+#define accelerationSampleRate getAccelODR
+#define gyroscopeSampleRate getGyroODR
+#define magneticFieldSampleRate getMagnetODR
+
+#define setAccelerationSampleRate setAccelODR		//development
+#define setGyroscopeSampleRate setGyroODR			//development
+#define setMagnetisFieldSampleRate setMagnetODR		// development
+
+#define accelerationFullScale getAccelFS			//development
+#define gyroscopeFullScale getGyroFS				//development
+#define magneticFieldFullScale getMagnetFS			//development
+
+#define setAccelerationFullScale setAccelFS			//development
+#define setGyroscopeFullScale setGyroFS				//development
+#define setMagneticFieldFullScale setMagnetFS		//development
+
+#define readAcceleration readAccel		
+#define readGyroscope readGyro
+#define readMagneticField readMagnet
+
+#define accelerationAvailable accelAvailable
+#define gyroscopeAvailable gyroAvailable
+#define magneticFieldAvailable magnetAvailable
 
 #include <Arduino.h>
 #include <Wire.h>
+#define GAUSS             0.01           
+#define MICROTESLA        1.0       // default
+#define NANOTESLA         1000.0  
+#define GRAVITY           1.0       // default
+#define METERPERSECOND2   9.81  
+#define DEGREEPERSECOND   1.0       //default
+#define RADIANSPERSECOND  3.141592654/180
 
 class LSM9DS1Class {
   public:
@@ -34,19 +73,47 @@ class LSM9DS1Class {
     void setOneShotMode();
 
     // Accelerometer
-    virtual int readAcceleration(float& x, float& y, float& z); // Results are in G (earth gravity).
-    virtual int accelerationAvailable(); // Number of samples in the FIFO.
-    virtual float accelerationSampleRate(); // Sampling rate of the sensor.
+    float accelOffset[3] = {0,0,0}; // zero point offset correction factor for calibration
+	float accelSlope[3] = {1,1,1};  // slope correction factor for calibration
+	float accelUnit = GRAVITY;      //  GRAVITY   OR  METERPERSECOND2 
+    virtual int   readAccel(float& x, float& y, float& z); // Results are in G (earth gravity) or m/s2.
+    virtual int   accelAvailable(); // Number of samples in the FIFO.
+	virtual void  setAccelOffset(float x, float y, float z);  //Look out, from measurements only
+	virtual void  setAccelSlope(float x, float y, float z);
+    virtual int   setAccelODR(int8_t range); // Sample Rate 0:off, 1:10Hz, 2:50Hz, 3:119Hz, 4:238Hz, 5:476Hz, 6:952Hz, 7:NA Automatic setting of BW
+    virtual float getAccelODR(); // Sample Rate of the sensor.
+    virtual float setAccelBW(int8_t range); //0,1,2,3 Override autoBandwidth setting see doc.table 67
+    virtual float getAccelBW();  //Bandwidth setting 0,1,2,3  see documentation table 67
+    virtual int   setAccelFS(int8_t range); // 0: ±2g ; 1: ±16g ; 2: ±4g ; 3: ±8g
+    virtual float getAccelFS(); // Full Scale setting (output = 2.0,  16.0 , 4.0 , 8.0)  
 
     // Gyroscope
-    virtual int readGyroscope(float& x, float& y, float& z); // Results are in degrees/second.
-    virtual int gyroscopeAvailable(); // Number of samples in the FIFO.
-    virtual float gyroscopeSampleRate(); // Sampling rate of the sensor.
+	float gyroOffset[3] = {0,0,0};      // zero point offset correction factor for calibration
+	float gyroSlope[3] = {1,1,1};  // slope correction factor for calibration
+    float gyroUnit = DEGREEPERSECOND;   // DEGREEPERSECOND   or  RADIANSPERSECOND
+    virtual int   readGyro(float& x, float& y, float& z); // Results are in degrees/second or rad/s.
+    virtual int   gyroAvailable(); // Number of samples in the FIFO.
+	virtual void  setGyroOffset(float x, float y, float z);  //Look out, from measurements only
+	virtual void  setGyroSlope(float x, float y, float z);
+    virtual int   setGyroODR(int8_t range); //Sampling Rate 0:off, 1:10Hz, 2:50Hz, 3:119Hz, 4:238Hz, 5:476Hz, 6:952Hz, 7:NA
+    virtual float getGyroODR(); // Sampling rate of the sensor.
+    virtual int   setGyroBW(int8_t range);  //Bandwidth setting 0,1,2,3  see documentation table 46 and 47
+    virtual float getGyroBW();  //Bandwidth setting 0,1,2,3  see documentation table 46 and 47
+    virtual int   setGyroFS(int8_t range); // (0= ±245 dps; 1= ±500 dps; 2= ±1000 dps; 3= ±2000 dps)
+    virtual float getGyroFS(); //  (output = 245.0,  500.0 , 1000.0, 2000.0) 
 
     // Magnetometer
-    virtual int readMagneticField(float& x, float& y, float& z); // Results are in uT (micro Tesla).
-    virtual int magneticFieldAvailable(); // Number of samples in the FIFO.
-    virtual float magneticFieldSampleRate(); // Sampling rate of the sensor.
+	float magnetOffset[3] = {0,0,0}; // zero point offset correction factor for calibration
+	float magnetSlope[3] = {1,1,1};  // slope correction factor for calibration
+    float magnetUnit = MICROTESLA;  //  GAUSS  or MICROTESLA 
+    virtual int   readMagnet(float& x, float& y, float& z); // Default results are in uT (micro Tesla) 
+    virtual int   magnetAvailable(); // Number of samples in the FIFO.
+	virtual void  setMagnetOffset(float x, float y, float z);  //Look out, from measurements only
+	virtual void  setMagnetSlope(float x, float y, float z);
+    virtual int   setMagnetODR(int8_t range); // Sampling rate (0..7) corresponds to {0.625,1.25,2.5,5.0,10.0,20.0,40.0,80.0}Hz
+    virtual float getMagnetODR(); // Sampling rate of the sensor in Hz.
+    virtual int   setMagnetFS(int8_t range); // 0=400.0; 1=800.0; 2=1200.0 , 3=1600.0  (µT)
+    virtual float getMagnetFS(); //  get chip's full scale setting  
 
   private:
     bool continuousMode;


### PR DESCRIPTION
New version of the LSM9DS1 library for the IMU chip. It was tested on a Nano 33 BLE Sense board and should be backwards compatible with V1.01.0.  

New for all 9 DOF is the possibility:
 to give it calibration zero offset and slope factors. 
 to change the output unit
 to set and get the ODR sample rate frequency ,
 to set and get the internal full scale setting of the chip (IFS) giving it more accuracy at the expense of the range.

Several fixed values in version 1.01 are replaced by functions that produce the value according to the current chip register setting. As a result there are a lot of new set... and get... functions.

Offset and Slope are organised in such way that they can be calibrated separately or together. Their values are independent of the full scale setting or the output unit. Copy their values in a new sketch and it will return calibrated output even when you choose to view it in a different setting. 
The voids  set...Offset  and  set...Slope are made for calibration purposes only. To store their values from read measurements according to the above features. Perhaps they need a better name to reflect this.