### PR TITLE
Add ability to read raw ADC counts for accel/gyro/mag as int16

### DIFF
--- a/src/LSM9DS1.h
+++ b/src/LSM9DS1.h
@@ -1,11 +1,11 @@
 /*
 
   This file is part of the Arduino_LSM9DS1 library.
-  New version written by Femme Verbeek, Pijnacker, the Netherlands 
+  New version written by Femme Verbeek, Pijnacker, the Netherlands
   Released to the public domain
   version 2
   Release Date 5 june 2020
-  
+
   Original notice:
   Copyright (c) 2019 Arduino SA. All rights reserved.
 
@@ -22,12 +22,12 @@
   You should have received a copy of the GNU Lesser General Public
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-  
+
 */
 
 #ifndef LSM9DS1_V2
       #define LSM9DS1_V2
-#endif	  
+#endif
 
 #define accelerationSampleRate getAccelODR
 #define gyroscopeSampleRate getGyroODR
@@ -45,7 +45,7 @@
 #define setGyroscopeFullScale setGyroFS				//development
 #define setMagneticFieldFullScale setMagnetFS		//development
 
-#define readAcceleration readAccel		
+#define readAcceleration readAccel
 #define readGyroscope readGyro
 #define readMagneticField readMagnet
 
@@ -55,14 +55,14 @@
 
 #include <Arduino.h>
 #include <Wire.h>
-#define GAUSS             0.01           
+#define GAUSS             0.01
 #define MICROTESLA        1.0       // default
-#define NANOTESLA         1000.0  
+#define NANOTESLA         1000.0
 #define GRAVITY           1.0       // default
-#define METERPERSECOND2   9.81  
+#define METERPERSECOND2   9.81
 #define DEGREEPERSECOND   1.0       //default
 #define RADIANSPERSECOND  3.141592654/180
-#define REVSPERMINUTE     60.0/360.0 
+#define REVSPERMINUTE     60.0/360.0
 #define REVSPERSECOND     1.0/360.0
 
 class LSM9DS1Class {
@@ -81,9 +81,10 @@ class LSM9DS1Class {
     // Accelerometer
     float accelOffset[3] = {0,0,0}; // zero point offset correction factor for calibration
     float accelSlope[3] = {1,1,1};  // slope correction factor for calibration
-    float accelUnit = GRAVITY;      //  GRAVITY   OR  METERPERSECOND2 
+    float accelUnit = GRAVITY;      //  GRAVITY   OR  METERPERSECOND2
     virtual int   readAccel(float& x, float& y, float& z); // Return calibrated data in unit of choise G or m/s2.
-    virtual int   readRawAccel(float& x, float& y, float& z); // Return uncalibrated results  
+    virtual int   readRawAccelInt16(int16_t& x, int16_t& y, int16_t& z);
+    virtual int   readRawAccel(float& x, float& y, float& z); // Return uncalibrated results
     virtual int   accelAvailable(); // Number of samples in the FIFO.
     virtual void  setAccelOffset(float x, float y, float z);  //Store zero-point measurements as offset
     virtual void  setAccelSlope(float x, float y, float z);   //Store measurements as slope
@@ -92,37 +93,39 @@ class LSM9DS1Class {
     virtual float setAccelBW(uint8_t range); //0,1,2,3 Override autoBandwidth setting see doc.table 67
     virtual float getAccelBW();  //Bandwidth setting 0,1,2,3  see documentation table 67
     virtual int   setAccelFS(uint8_t range); // 0: ±2g ; 1: ±24g ; 2: ±4g ; 3: ±8g
-    virtual float getAccelFS(); // Full Scale setting (output = 2.0,  24.0 , 4.0 , 8.0)  
+    virtual float getAccelFS(); // Full Scale setting (output = 2.0,  24.0 , 4.0 , 8.0)
 
     // Gyroscope
     float gyroOffset[3] = {0,0,0};      // zero point offset correction factor for calibration
     float gyroSlope[3] = {1,1,1};  		// slope correction factor for calibration
     float gyroUnit = DEGREEPERSECOND;   // DEGREEPERSECOND  RADIANSPERSECOND REVSPERMINUTE REVSPERSECOND
     virtual int   readGyro(float& x, float& y, float& z); // Return calibrated data in in unit of choise °/s or rad/s.
-    virtual int   readRawGyro(float& x, float& y, float& z); // Return uncalibrated results 
+    virtual int   readRawGyro(float& x, float& y, float& z); // Return uncalibrated results
+    virtual int   readRawGyroInt16(int16_t& x, int16_t& y, int16_t& z);
     virtual int   gyroAvailable(); 		// Number of samples in the FIFO.
     virtual void  setGyroOffset(float x, float y, float z);  //Store zero-point measurements as offset
     virtual void  setGyroSlope(float x, float y, float z);   //Store measurements as slope
-    virtual int   setGyroODR(uint8_t range); //Sample Rate Hz 0:off,1:10,2:50 3:119,4:238,5:476,6:does not work 952Hz 
+    virtual int   setGyroODR(uint8_t range); //Sample Rate Hz 0:off,1:10,2:50 3:119,4:238,5:476,6:does not work 952Hz
     virtual float getGyroODR(); // Measured Sample rate of the sensor.
     virtual int   setGyroBW(uint8_t range);  //Bandwidth setting 0,1,2,3  see documentation table 46 and 47
     virtual float getGyroBW();  //Bandwidth setting 0,1,2,3  see documentation table 46 and 47
     virtual int   setGyroFS(uint8_t range); // (0= ±245 dps; 1= ±500 dps; 2= ±1000 dps; 3= ±2000 dps)
-    virtual float getGyroFS(); //  (output = 245.0,  500.0 , 1000.0, 2000.0) 
+    virtual float getGyroFS(); //  (output = 245.0,  500.0 , 1000.0, 2000.0)
 
     // Magnetometer
     float magnetOffset[3] = {0,0,0}; // zero point offset correction factor for calibration
     float magnetSlope[3] = {1,1,1};  // slope correction factor for calibration
     float magnetUnit = MICROTESLA;  //  GAUSS,  MICROTESLA NANOTESLA
-    virtual int   readMagnet(float& x, float& y, float& z); // Return calibrated data in unit of choise µT , nT or G 
-    virtual int   readRawMagnet(float& x, float& y, float& z); // Return uncalibrated results 
+    virtual int   readMagnet(float& x, float& y, float& z); // Return calibrated data in unit of choise µT , nT or G
+    virtual int   readRawMagnet(float& x, float& y, float& z); // Return uncalibrated results
+    virtual int   readRawMagnetInt16(int16_t& x, int16_t& y, int16_t& z);
     virtual int   magnetAvailable(); // Number of samples in the FIFO.
     virtual void  setMagnetOffset(float x, float y, float z);  //Store zero-point measurements as offset
     virtual void  setMagnetSlope(float x, float y, float z);   //Store measurements as slope
     virtual int   setMagnetODR(uint8_t range); // Sampling rate (0..8)->{0.625,1.25,2.5,5.0,10,20,40,80,400}Hz
     virtual float getMagnetODR(); // Sampling rate of the sensor in Hz.
     virtual int   setMagnetFS(uint8_t range); // 0=±400.0; 1=±800.0; 2=±1200.0 , 3=±1600.0  (µT)
-    virtual float getMagnetFS(); //  get chip's full scale setting  
+    virtual float getMagnetFS(); //  get chip's full scale setting
 
   private:
     unsigned long ODRCalibrationTime=250000; //µs


### PR DESCRIPTION
Adding the ability to read Raw Int16 values form the IMU gives a developer more ability to scale to any given units or use the raw counts themselves. 

Whitespace changes come from auto-trim of whitespace on save. 

usage is the same as read()/readRaw()

```
int16_t x,y,z;
IMU.readRawAccelInt16(x,y,z);
```