### PR TITLE
Save I2C Time, don't read values already known

### DIFF
--- a/src/LSM9DS1.cpp
+++ b/src/LSM9DS1.cpp
@@ -63,6 +63,10 @@ int LSM9DS1Class::begin()
 {
   _wire->begin();
 
+  storedAccelFS = false;
+  storedGyroFS = false;
+  storedMagnetFS = false;    
+  
   // reset
   writeRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG8, 0x05);
   writeRegister(LSM9DS1_ADDRESS_M, LSM9DS1_CTRL_REG2_M, 0x0c);
@@ -242,13 +246,18 @@ int LSM9DS1Class::setAccelFS(uint8_t range) // 0: ±2g ; 1: ±16g ; 2: ±4g ; 3:
 {	if (range >=4) return 0;
     range = (range & 0b00000011) << 3;
 	uint8_t setting = ((readRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG6_XL) & 0xE7) | range);
-	return writeRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG6_XL,setting) ;
+	lastAccelFS = setting;
+  storedAccelFS = true;
+  return writeRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG6_XL,setting) ;
 }
 
 float LSM9DS1Class::getAccelFS() // Full scale dimensionless, but its value corresponds to g
-{   float ranges[] ={2.0, 24.0, 4.0, 8.0}; //g
-    uint8_t setting = (readRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG6_XL) & 0x18) >> 3;
-    return ranges[setting] ;
+{ float ranges[] ={2.0, 24.0, 4.0, 8.0}; //g
+  if(!storedAccelFS) {
+    lastAccelFS = (readRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG6_XL) & 0x18) >> 3;
+    storedAccelFS = true;
+  }     
+  return ranges[lastAccelFS] ;
 }
 
 //************************************      Gyroscope      *****************************************
@@ -369,13 +378,18 @@ int LSM9DS1Class::setGyroFS(uint8_t range) // (0: 245 dps; 1: 500 dps; 2: 1000  
 {  if (range >=4) return 0;
    range = (range & 0b00000011) << 3;	
    uint8_t setting = ((readRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG1_G) & 0xE7) | range );
+   lastGyroFS = setting;
+   storedGyroFS = true;
    return writeRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG1_G,setting) ;
 }
 
 float LSM9DS1Class::getGyroFS() //   dimensionless, but its value defaults to deg/s
 { float Ranges[] ={245.0, 500.0, 1000.0, 2000.0}; //dps
-  uint8_t setting = (readRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG1_G) & 0x18) >> 3;
-  return Ranges[setting] ;
+  if(!storedGyroFS) {
+    lastGyroFS = (readRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG1_G) & 0x18) >> 3;
+    storedGyroFS = true;
+  }
+  return Ranges[lastGyroFS] ;
 }
 
 //************************************      Magnetic field      *****************************************
@@ -431,13 +445,18 @@ void LSM9DS1Class::setMagnetSlope(float x, float y, float z)
 int LSM9DS1Class::setMagnetFS(uint8_t range) // 0=400.0; 1=800.0; 2=1200.0 , 3=1600.0  (µT)
 {  if (range >=4) return 0;
    range = (range & 0b00000011) << 5;	
+   lastMagnetFS = range;
+   storedMagnetFS = true;
    return writeRegister(LSM9DS1_ADDRESS_M, LSM9DS1_CTRL_REG2_M,range) ;
 }
 
 float LSM9DS1Class::getMagnetFS() //   dimensionless, but its value defaults to µT
 { const float Ranges[] ={400.0, 800.0, 1200.0, 1600.0}; //
-  uint8_t setting = readRegister(LSM9DS1_ADDRESS_M, LSM9DS1_CTRL_REG2_M)  >> 5;
-  return  Ranges[setting] ;
+  if(!storedMagnetFS) {
+    lastMagnetFS = readRegister(LSM9DS1_ADDRESS_M, LSM9DS1_CTRL_REG2_M)  >> 5;
+    storedMagnetFS = true;
+  }
+  return  Ranges[lastMagnetFS] ;
 }
 
 int LSM9DS1Class::setMagnetODR(uint8_t range)  // range (0..8) = {0.625,1.25,2.5,5,10,20,40,80,400}Hz

--- a/src/LSM9DS1.h
+++ b/src/LSM9DS1.h
@@ -82,6 +82,8 @@ class LSM9DS1Class {
     float accelOffset[3] = {0,0,0}; // zero point offset correction factor for calibration
     float accelSlope[3] = {1,1,1};  // slope correction factor for calibration
     float accelUnit = GRAVITY;      //  GRAVITY   OR  METERPERSECOND2 
+    uint8_t lastAccelFS;
+    bool    storedAccelFS;    
     virtual int   readAccel(float& x, float& y, float& z); // Return calibrated data in unit of choise G or m/s2.
     virtual int   readRawAccel(float& x, float& y, float& z); // Return uncalibrated results  
     virtual int   accelAvailable(); // Number of samples in the FIFO.
@@ -98,6 +100,8 @@ class LSM9DS1Class {
     float gyroOffset[3] = {0,0,0};      // zero point offset correction factor for calibration
     float gyroSlope[3] = {1,1,1};  		// slope correction factor for calibration
     float gyroUnit = DEGREEPERSECOND;   // DEGREEPERSECOND  RADIANSPERSECOND REVSPERMINUTE REVSPERSECOND
+    uint8_t lastGyroFS;
+    bool    storedGyroFS;   
     virtual int   readGyro(float& x, float& y, float& z); // Return calibrated data in in unit of choise °/s or rad/s.
     virtual int   readRawGyro(float& x, float& y, float& z); // Return uncalibrated results 
     virtual int   gyroAvailable(); 		// Number of samples in the FIFO.
@@ -114,6 +118,8 @@ class LSM9DS1Class {
     float magnetOffset[3] = {0,0,0}; // zero point offset correction factor for calibration
     float magnetSlope[3] = {1,1,1};  // slope correction factor for calibration
     float magnetUnit = MICROTESLA;  //  GAUSS,  MICROTESLA NANOTESLA
+    uint8_t lastMagnetFS;
+    bool    storedMagnetFS; 
     virtual int   readMagnet(float& x, float& y, float& z); // Return calibrated data in unit of choise µT , nT or G 
     virtual int   readRawMagnet(float& x, float& y, float& z); // Return uncalibrated results 
     virtual int   magnetAvailable(); // Number of samples in the FIFO.


### PR DESCRIPTION
This saves quite a bit of I2C time by not reading the full scale every time when it's already been read once. In theory it shouldn't ever change after the first read or it gets changed.

BTW.. Lot nicer library that orig!